### PR TITLE
Fix for job retries

### DIFF
--- a/azuredevops/templates/conda-setup-step-template.yml
+++ b/azuredevops/templates/conda-setup-step-template.yml
@@ -57,4 +57,4 @@ steps:
   displayName: "Publish environment info to artifact ${{parameters.envInfoArtifact}}"
   inputs:
     path: '$(System.DefaultWorkingDirectory)/${{parameters.envInfoDirectory}}'
-    artifact: ${{parameters.envInfoArtifact}}
+    artifact: '${{parameters.envInfoArtifact}}-Attempt-$(System.JobAttempt)'


### PR DESCRIPTION
Retrying jobs would often fail because build Artifacts are immutable and the 'environment info' artifact would already exist. Append the retry count to the artifact name to work around this.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>