### PR TITLE
release interpret-text 0.1.3

### DIFF
--- a/python/interpret_text/__init__.py
+++ b/python/interpret_text/__init__.py
@@ -5,7 +5,7 @@ import atexit
 
 _major = "0"
 _minor = "1"
-_patch = "2"
+_patch = "3"
 
 __name__ = "interpret-text"
 __version__ = "{}.{}.{}.dev10".format(_major, _minor, _patch)

--- a/tools/generate_conda_files.py
+++ b/tools/generate_conda_files.py
@@ -38,6 +38,7 @@ CONDA_BASE = {
     "pytorch": "pytorch-cpu>=1.0.0",
     "scipy": "scipy>=1.0.0",
     "tensorflow": "tensorflow<2.0.0",
+    "tensorflow-estimator": "tensorflow-estimator<2.0.0",
     "h5py": "h5py>=2.8.0",
     "py-xgboost": "py-xgboost<=0.80"
 }


### PR DESCRIPTION
- update dependencies in interpret-text
- fix pickle of classical text explainer
- new release pipeline to release package to pypi
- several unit tests and notebook updates since last release
- also fixes a build failure due tensorflow-estimators dependency being incompatible with tensorflow for generated environment (it needs to be less than 2.0 version)