### PR TITLE
fix interpret-text release version to be non-dev

### DIFF
--- a/python/interpret_text/__init__.py
+++ b/python/interpret_text/__init__.py
@@ -8,7 +8,7 @@ _minor = "1"
 _patch = "3"
 
 __name__ = "interpret-text"
-__version__ = "{}.{}.{}.dev10".format(_major, _minor, _patch)
+__version__ = "{}.{}.{}".format(_major, _minor, _patch)
 
 # Only log to disk if environment variable specified
 interpret_text_logs = os.environ.get('INTERPRET_TEXT_LOGS')


### PR DESCRIPTION
remove the .dev10 from released pypi package version