### PR TITLE
rename branch master to main for interpret-text repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Contributions are welcomed! Here's a few things to know:
 
 ## Steps to Contributing
 
-*Prs are made against Master and releases are made from Master.
+*Prs are made against main and releases are made from main.
 
 ## Coding Guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Interpret-Text - Alpha Release 
-<img alt="PyPI" src="https://img.shields.io/pypi/v/interpret-text"> <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/interpret-text"> <img alt="GitHub" src="https://img.shields.io/github/license/interpretml/interpret-text"> [![Build Status](https://dev.azure.com/responsibleai/interpret-text/_apis/build/status/CPU%20unit%20tests%20-%20linux?branchName=master&jobName=cpu_unit_tests_linux)](https://dev.azure.com/responsibleai/interpret-text/_build/latest?definitionId=62&branchName=master) 
-    [![Build Status](https://dev.azure.com/responsibleai/interpret-text/_apis/build/status/CPU%20integration%20tests%20-%20linux?branchName=master&jobName=cpu_integration_tests_linux)](https://dev.azure.com/responsibleai/interpret-text/_build/latest?definitionId=61&branchName=master)
+<img alt="PyPI" src="https://img.shields.io/pypi/v/interpret-text"> <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/interpret-text"> <img alt="GitHub" src="https://img.shields.io/github/license/interpretml/interpret-text"> [![Build Status](https://dev.azure.com/responsibleai/interpret-text/_apis/build/status/CPU%20unit%20tests%20-%20linux?branchName=main&jobName=cpu_unit_tests_linux)](https://dev.azure.com/responsibleai/interpret-text/_build/latest?definitionId=62&branchName=main) 
+    [![Build Status](https://dev.azure.com/responsibleai/interpret-text/_apis/build/status/CPU%20integration%20tests%20-%20linux?branchName=main&jobName=cpu_integration_tests_linux)](https://dev.azure.com/responsibleai/interpret-text/_build/latest?definitionId=61&branchName=main)
 
 
 
@@ -140,7 +140,7 @@ The following is a list of the explainers available in this repository:
 | Explain BERT | No | Yes  | Yes  |
 | Explain RNN  | No | No | Yes |
 | NLP pipeline support | Handles text pre-processing, encoding, training, hyperparameter tuning | Uses BERT tokenizer however user needs to supply trained/fine-tuned BERT model, and samples of trained data | Generator and predictor modules handle the required text pre-processing.
-| Sample notebook | [Classical Text Explainer Sample Notebook](https://nbviewer.jupyter.org/github/interpretml/interpret-text/blob/master/notebooks/text_classification/text_classification_classical_text_explainer.ipynb) | [Unified Information Explainer Sample Notebook](https://nbviewer.jupyter.org/github/interpretml/interpret-text/blob/master/notebooks/text_classification/text_classification_unified_information_explainer.ipynb) | [Introspective Rationale Explainer Sample Notebook](https://nbviewer.jupyter.org/github/interpretml/interpret-text/blob/master/notebooks/text_classification/text_classification_introspective_rationale_explainer.ipynb)|
+| Sample notebook | [Classical Text Explainer Sample Notebook](https://nbviewer.jupyter.org/github/interpretml/interpret-text/blob/main/notebooks/text_classification/text_classification_classical_text_explainer.ipynb) | [Unified Information Explainer Sample Notebook](https://nbviewer.jupyter.org/github/interpretml/interpret-text/blob/main/notebooks/text_classification/text_classification_unified_information_explainer.ipynb) | [Introspective Rationale Explainer Sample Notebook](https://nbviewer.jupyter.org/github/interpretml/interpret-text/blob/main/notebooks/text_classification/text_classification_introspective_rationale_explainer.ipynb)|
 
 ## Classical Text Explainer
 

--- a/azuredevops/Code-Coverage.yml
+++ b/azuredevops/Code-Coverage.yml
@@ -13,7 +13,7 @@ schedules:
   displayName: Nightly Code Coverage Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 jobs:

--- a/azuredevops/Nightly.yml
+++ b/azuredevops/Nightly.yml
@@ -13,7 +13,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 pool:

--- a/azuredevops/PR-Gate.yml
+++ b/azuredevops/PR-Gate.yml
@@ -5,7 +5,7 @@ variables:
   EnvFileStem: 'environment'
 
 pr:
-- master
+- main
 
 trigger: none # No CI build
 

--- a/python/interpret_text/experimental/widget/README.md
+++ b/python/interpret_text/experimental/widget/README.md
@@ -12,9 +12,9 @@ Once the Typescript code has been built using the dashboard build instructions, 
 
 ### Understanding the contracts
 The widget contract is defined between 
-[ExplanationWidget.py](https://github.com/microsoft/interpret-community-text/blob/master/python/interpret_text/widget/ExplanationWidget.py) and the [explanationDashboard.tsx](https://github.com/microsoft/interpret-community-text/blob/eac1b7a57f1d2c1b9e9fa22aca237e0cc97b454b/python/interpret_text/widget/js/src/explanationDashboard.tsx) (in widget/js/src). These two files must be in sync for the dashboard to instantiate.
+[ExplanationWidget.py](https://github.com/interpretml/interpret-text/blob/main/python/interpret_text/experimental/widget/ExplanationWidget.py) and the [explanationDashboard.tsx](https://github.com/interpretml/interpret-text/blob/main/python/interpret_text/experimental/widget/js/src/explanationDashboard.tsx) (in widget/js/src). These two files must be in sync for the dashboard to instantiate.
 
-Additionally, the  [ExplanationDashboard.py](https://github.com/microsoft/interpret-community-text/blob/master/python/interpret_text/widget/ExplanationDashboard.py) takes in an Explanation Object which is used to initialize the dashboard. 
+Additionally, the  [ExplanationDashboard.py](https://github.com/interpretml/interpret-text/blob/main/python/interpret_text/experimental/widget/ExplanationDashboard.py) takes in an Explanation Object which is used to initialize the dashboard. 
 
 
 
@@ -22,13 +22,13 @@ Additionally, the  [ExplanationDashboard.py](https://github.com/microsoft/interp
 ## Build
 Run the following commands 
 
-- From interpret-community-text\python\interpret_text\widget\js
+- From interpret-text\python\interpret_text\widget\js
 	> npm install
 	> npm run-script build:all
 
 - Manually delete the folder called node_modules from the current folder
 
-- From interpret-community-text\python
+- From interpret-text\python
 	> pip install .
 
 After you delete the node_modules folder, the widget needs to be installed which is why you run the last command. Similarly, you can also update the pypi feed with the new files in the static folder so users can upgrade their interpret-text package with the most up-to-date dashboard.

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ Tests are automatically run as part of a DevOps pipeline. The pipelines are defi
 <details>
 <summary><strong><em>Unit tests (click to expand)</em></strong></summary>
 
-Unit tests ensure that each class or function behaves as it should. Every time a developer makes a pull request to staging or master branch, a battery of unit tests is executed.
+Unit tests ensure that each class or function behaves as it should. Every time a developer makes a pull request to main branch, a battery of unit tests is executed.
 
 **Note that the next instructions execute the tests from the root folder.**
 
@@ -43,6 +43,6 @@ In the notebooks of these repo we use [Papermill](https://github.com/nteract/pap
 
 In the unit tests we just make sure the notebook runs. In the integration tests, we use a bigger dataset for more epochs and we test that the metrics are what we expect.
 
-For a deep overview on how to integrate papermill on unit and integration test, please refer to [this guide from Microsoft Recommenders repo](https://github.com/microsoft/recommenders/blob/master/tests/README.md#how-to-create-tests-on-notebooks-with-papermill).
+For a deep overview on how to integrate papermill on unit and integration test, please refer to [this guide from Recommenders repo](https://github.com/recommenders-team/recommenders/tree/main/tests#how-to-create-tests-for-the-notebooks).
 
 More details on how to integrate Papermill with notebooks can be found in their [repo](https://github.com/nteract/papermill).

--- a/visualization/README.md
+++ b/visualization/README.md
@@ -12,7 +12,7 @@ The visualization dashboard is a modular component that will take in an Explanat
 ### Setting up your environment
 The dashboard uses Typescript and React as it's main language and framework. NPM is the package management system that will be used throughout this document, but other package management systems can be used.
 ### Feature Development
-The dashboard currently uses [Office UI Fabric](https://developer.microsoft.com/en-us/fabric#/get-started) and [mlchartlib](https://github.com/interpretml/interpret-community/tree/master/visualization/mlchartlib) for development.
+The dashboard currently uses [Office UI Fabric](https://developer.microsoft.com/en-us/fabric#/get-started) and [mlchartlib](https://github.com/microsoft/responsible-ai-toolbox/tree/main/libs/mlchartlib) for development.
 
 The source code is broken into localization and MLIDashboard. Localization is used as to display the static strings in the dashboard to different languages, while MLIDashboard houses the Typescript code for functionality.
 


### PR DESCRIPTION
Rename the master branch to main for the interpret-text repository.
Also fixes several old broken links in the documentation.