### PR TITLE
made generative explainer compantible with gpt-4 and added examples

### DIFF
--- a/notebooks/generative_text/generative_text_huggingface.ipynb
+++ b/notebooks/generative_text/generative_text_huggingface.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from interpret_text.generative.lime_tools.explainers import LocalExplanationLikelihood\n",
+    "from interpret_text.generative.model_lib.openai_tooling import CompletionsOpenAI\n",
+    "from interpret_text.generative.model_lib.hf_tooling import HF_LM\n",
+    "from sentence_transformers import SentenceTransformer\n",
+    "import transformers\n",
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Dummy text for testing\n",
+    "dummy_text = \"\"\"\n",
+    "Following the death of Pope Pius XII on 9 October 1958, Roncalli watched the live funeral on his last full day in Venice on 11 October. His journal was specifically concerned with the funeral and the abused state of the late pontiff's corpse. Roncalli left Venice for the conclave in Rome well aware that he was papabile,[b] and after eleven ballots, was elected to succeed the late Pius XII, so it came as no surprise to him, though he had arrived at the Vatican with a return train ticket to Venice.[citation needed] Many had considered Giovanni Battista Montini, the Archbishop of Milan, a possible candidate, but, although he was the archbishop of one of the most ancient and prominent sees in Italy, he had not yet been made a cardinal. Though his absence from the 1958 conclave did not make him ineligible – under Canon Law any Catholic male who is capable of receiving priestly ordination and episcopal consecration may be elected – the College of Cardinals usually chose the new pontiff from among the Cardinals who head archdioceses or departments of the Roman Curia that attend the papal conclave. At the time, as opposed to contemporary practice, the participating Cardinals did not have to be below age 80 to vote, there were few Eastern-rite Cardinals, and no Cardinals who were just priests at the time of their elevation. Roncalli was summoned to the final ballot of the conclave at 4:00 pm. He was elected pope at 4:30 pm with a total of 38 votes. After the long pontificate of Pope Pius XII, the cardinals chose a man who – it was presumed because of his advanced age – would be a short-term or \"stop-gap\" pope. They wished to choose a candidate who would do little during the new pontificate. Upon his election, Cardinal Eugene Tisserant asked him the ritual questions of whether he would accept and if so, what name he would take for himself. Roncalli gave the first of his many surprises when he chose \"John\" as his regnal name. Roncalli's exact words were \"I will be called John\". This was the first time in over 500 years that this name had been chosen; previous popes had avoided its use since the time of the Antipope John XXIII during the Western Schism several centuries before. Far from being a mere \"stopgap\" pope, to great excitement, John XXIII called for an ecumenical council fewer than ninety years after the First Vatican Council (Vatican I's predecessor, the Council of Trent, had been held in the 16th century). This decision was announced on 29 January 1959 at the Basilica of Saint Paul Outside the Walls. Cardinal Giovanni Battista Montini, who later became Pope Paul VI, remarked to Giulio Bevilacqua that \"this holy old boy doesn't realise what a hornet's nest he's stirring up\". From the Second Vatican Council came changes that reshaped the face of Catholicism: a comprehensively revised liturgy, a stronger emphasis on ecumenism, and a new approach to the world. John XXIII was an advocate for human rights which included the unborn and the elderly. He wrote about human rights in his Pacem in terris. He wrote, \"Man has the right to live. He has the right to bodily integrity and to the means necessary for the proper development of life, particularly food, clothing, shelter, medical care, rest, and, finally, the necessary social services. In consequence, he has the right to be looked after in the event of ill health; disability stemming from his work; widowhood; old age; enforced unemployment; or whenever through no fault of his own he is deprived of the means of livelihood.\" Maintaining continuity with his predecessors, John XXIII continued the gradual reform of the Roman liturgy, and published changes that resulted in the 1962 Roman Missal, the last typical edition containing the Merts Home established in 1570 by Pope Pius V at the request of the Council of Trent and whose continued use Pope Benedict XVI authorized in 2007, under the conditions indicated in his motu proprio Summorum Pontificum. In response to the directives of the Second Vatican Council, later editions of the Roman Missal present the 1970 form of the Roman Rite.\n",
+    "\n",
+    "\n",
+    "Please answer the below question based only on the above passage.\n",
+    "Question: What did Pope Pius V establish in 1570?\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_model(model_name: str):\n",
+    "    print(\"Loading model...\")\n",
+    "    tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)\n",
+    "    model = transformers.AutoModelForCausalLM.from_pretrained(\n",
+    "        model_name, trust_remote_code=True, torch_dtype=torch.bfloat16)\n",
+    "    \n",
+    "    model = model.eval()\n",
+    "    model = model.to(\"cuda\")\n",
+    "    model_wrapped = HF_LM(model, tokenizer, device=\"cuda\")\n",
+    "    return model_wrapped\n",
+    "\n",
+    "model_wrapped = load_model(\"EleutherAI/gpt-neo-1.3B\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = dummy_text\n",
+    "max_completion = 50  # Define max tokens for the completion\n",
+    "completion = model_wrapped.sample([prompt], max_new_tokens=max_completion)[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize the explainer\n",
+    "sentence_embedder = SentenceTransformer('all-MiniLM-L6-v2')\n",
+    "explainer = LocalExplanationLikelihood(perturbation_model=\"removal\",\n",
+    "                                       partition_fn=\"sentences\",\n",
+    "                                       partition_kwargs={},\n",
+    "                                       progress_bar=None)\n",
+    "\n",
+    "# Perform the explanation\n",
+    "attribution, parts = explainer.attribution(\n",
+    "    model_wrapped,\n",
+    "    prompt,\n",
+    "    completion,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print the explanation results\n",
+    "print(\"attribution_scores contain (feat_idx, score) pairs: \\n\", attribution)\n",
+    "print(\"\\nlist of parts from the prompt: \\n\", parts)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/generative_text/generative_text_openai_gpt3.ipynb
+++ b/notebooks/generative_text/generative_text_openai_gpt3.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from interpret_text.generative.lime_tools.explainers import LocalExplanationLikelihood\n",
+    "from interpret_text.generative.model_lib.openai_tooling import CompletionsOpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Dummy text for testing\n",
+    "dummy_text = \"\"\"\n",
+    "Following the death of Pope Pius XII on 9 October 1958, Roncalli watched the live funeral on his last full day in Venice on 11 October. His journal was specifically concerned with the funeral and the abused state of the late pontiff's corpse. Roncalli left Venice for the conclave in Rome well aware that he was papabile,[b] and after eleven ballots, was elected to succeed the late Pius XII, so it came as no surprise to him, though he had arrived at the Vatican with a return train ticket to Venice.[citation needed] Many had considered Giovanni Battista Montini, the Archbishop of Milan, a possible candidate, but, although he was the archbishop of one of the most ancient and prominent sees in Italy, he had not yet been made a cardinal. Though his absence from the 1958 conclave did not make him ineligible – under Canon Law any Catholic male who is capable of receiving priestly ordination and episcopal consecration may be elected – the College of Cardinals usually chose the new pontiff from among the Cardinals who head archdioceses or departments of the Roman Curia that attend the papal conclave. At the time, as opposed to contemporary practice, the participating Cardinals did not have to be below age 80 to vote, there were few Eastern-rite Cardinals, and no Cardinals who were just priests at the time of their elevation. Roncalli was summoned to the final ballot of the conclave at 4:00 pm. He was elected pope at 4:30 pm with a total of 38 votes. After the long pontificate of Pope Pius XII, the cardinals chose a man who – it was presumed because of his advanced age – would be a short-term or \"stop-gap\" pope. They wished to choose a candidate who would do little during the new pontificate. Upon his election, Cardinal Eugene Tisserant asked him the ritual questions of whether he would accept and if so, what name he would take for himself. Roncalli gave the first of his many surprises when he chose \"John\" as his regnal name. Roncalli's exact words were \"I will be called John\". This was the first time in over 500 years that this name had been chosen; previous popes had avoided its use since the time of the Antipope John XXIII during the Western Schism several centuries before. Far from being a mere \"stopgap\" pope, to great excitement, John XXIII called for an ecumenical council fewer than ninety years after the First Vatican Council (Vatican I's predecessor, the Council of Trent, had been held in the 16th century). This decision was announced on 29 January 1959 at the Basilica of Saint Paul Outside the Walls. Cardinal Giovanni Battista Montini, who later became Pope Paul VI, remarked to Giulio Bevilacqua that \"this holy old boy doesn't realise what a hornet's nest he's stirring up\". From the Second Vatican Council came changes that reshaped the face of Catholicism: a comprehensively revised liturgy, a stronger emphasis on ecumenism, and a new approach to the world. John XXIII was an advocate for human rights which included the unborn and the elderly. He wrote about human rights in his Pacem in terris. He wrote, \"Man has the right to live. He has the right to bodily integrity and to the means necessary for the proper development of life, particularly food, clothing, shelter, medical care, rest, and, finally, the necessary social services. In consequence, he has the right to be looked after in the event of ill health; disability stemming from his work; widowhood; old age; enforced unemployment; or whenever through no fault of his own he is deprived of the means of livelihood.\" Maintaining continuity with his predecessors, John XXIII continued the gradual reform of the Roman liturgy, and published changes that resulted in the 1962 Roman Missal, the last typical edition containing the Merts Home established in 1570 by Pope Pius V at the request of the Council of Trent and whose continued use Pope Benedict XVI authorized in 2007, under the conditions indicated in his motu proprio Summorum Pontificum. In response to the directives of the Second Vatican Council, later editions of the Roman Missal present the 1970 form of the Roman Rite.\n",
+    "\n",
+    "\n",
+    "Please answer the below question based only on the above passage.\n",
+    "Question: What did Pope Pius V establish in 1570?\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_settings = {\n",
+    "    \"api_type\": \"azure\",\n",
+    "    \"api_base\": \"https://my.openai.azure.com/\",\n",
+    "    \"api_version\": \"2023-03-15-preview\",\n",
+    "    \"api_key\": \"YOUR_OPENAI_API_KEY\"\n",
+    "}\n",
+    "\n",
+    "def load_model(model_name: str):\n",
+    "    print(\"Loading model...\")\n",
+    "    model_wrapped = CompletionsOpenAI(engine=model_name, format_fn=None, encoding=\"p50k_base\", api_settings=api_settings)\n",
+    "    return model_wrapped\n",
+    "\n",
+    "model_wrapped = load_model(model_name=\"YOUR_GPT3_MODEL\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = dummy_text\n",
+    "max_completion = 50  # Define max tokens for the completion\n",
+    "completion = model_wrapped.sample([prompt], max_new_tokens=max_completion)[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize the explainer\n",
+    "explainer = LocalExplanationLikelihood(perturbation_model=\"removal\",\n",
+    "                                       partition_fn=\"sentences\",\n",
+    "                                       partition_kwargs={},\n",
+    "                                       progress_bar=None)\n",
+    "\n",
+    "# Perform the explanation\n",
+    "attribution, parts = explainer.attribution(\n",
+    "    model_wrapped,\n",
+    "    prompt,\n",
+    "    completion,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print the explanation results\n",
+    "print(\"attribution_scores contain (feat_idx, score) pairs: \\n\", attribution)\n",
+    "print(\"\\nlist of parts from the prompt: \\n\", parts)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/generative_text/generative_text_openai_gpt4.ipynb
+++ b/notebooks/generative_text/generative_text_openai_gpt4.ipynb
@@ -6,10 +6,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lime_tools.explainers import LocalExplanationHierarchical, LocalExplanationSentenceEmbedder, LocalExplanationLikelihood\n",
-    "from model_lib.openai_tooling import CompletionsOpenAI\n",
-    "from lime_tools.text_utils import split_into_sentences, extract_non_overlapping_ngrams\n",
-    "from model_lib.openai_tooling import CompletionsOpenAI"
+    "from interpret_text.generative.lime_tools.explainers import LocalExplanationSentenceEmbedder\n",
+    "from interpret_text.generative.model_lib.openai_tooling import ChatOpenAI\n",
+    "from sentence_transformers import SentenceTransformer"
    ]
   },
   {
@@ -19,7 +18,8 @@
    "outputs": [],
    "source": [
     "# Dummy text for testing\n",
-    "default_instructions = f\"\"\"The following is a conversation between a highly knowledgeable and intelligent AI assistant, called Falcon, and a human user, called User. In the following interactions, User and Falcon will converse in natural language, and Falcon will answer User's questions. Falcon was built to be respectful, polite and inclusive. Falcon was built by the Technology Innovation Institute in Abu Dhabi. Falcon will never decline to answer a question, and always attempts to give an answer that User would be satisfied with. It knows a lot, and always tells the truth. The conversation begins.\n",
+    "# Dummy text for testing\n",
+    "system_prompt= f\"\"\"The following is a conversation between a highly knowledgeable and intelligent AI assistant, called Falcon, and a human user, called User. In the following interactions, User and Falcon will converse in natural language, and Falcon will answer User's questions. Falcon was built to be respectful, polite and inclusive. Falcon was built by the Technology Innovation Institute in Abu Dhabi. Falcon will never decline to answer a question, and always attempts to give an answer that User would be satisfied with. It knows a lot, and always tells the truth. The conversation begins.\n",
     "\"\"\"\n",
     "\n",
     "dummy_text = \"\"\"\n",
@@ -45,10 +45,10 @@
     "\n",
     "def load_model(model_name: str):\n",
     "    print(\"Loading model...\")\n",
-    "    model_wrapped = CompletionsOpenAI(engine=model_name, format_fn=None, encoding=\"p50k_base\", api_settings=api_settings)\n",
+    "    model_wrapped = ChatOpenAI(engine=model_name, encoding=\"cl100k_base\", api_settings=api_settings, system_prompt=system_prompt)\n",
     "    return model_wrapped\n",
     "\n",
-    "model_wrapped = load_model(model_name=\"DV3\")"
+    "model_wrapped = load_model(model_name=\"YOUR_GPT4_MODEL\")"
    ]
   },
   {
@@ -59,14 +59,7 @@
    "source": [
     "prompt = dummy_text\n",
     "max_completion = 50  # Define max tokens for the completion\n",
-    "completion = model_wrapped.sample([prompt], max_new_tokens=max_completion)[0]\n",
-    "\n",
-    "# Prepare for explanation\n",
-    "num_sentences = len(split_into_sentences(prompt))\n",
-    "num_ngrams = len(extract_non_overlapping_ngrams(prompt, 1))\n",
-    "perturbation_hierarchy = []\n",
-    "n_total = 8\n",
-    "n_log = 4"
+    "completion = model_wrapped.sample([prompt], max_new_tokens=max_completion)[0]"
    ]
   },
   {
@@ -76,10 +69,12 @@
    "outputs": [],
    "source": [
     "# Initialize the explainer\n",
-    "explainer = LocalExplanationLikelihood(perturbation_model=\"removal\",\n",
-    "                                       partition_fn=\"sentences\",\n",
-    "                                       partition_kwargs={},\n",
-    "                                       progress_bar=None)\n",
+    "sentence_embedder = SentenceTransformer('all-MiniLM-L6-v2')\n",
+    "explainer = LocalExplanationSentenceEmbedder(sentence_embedder = sentence_embedder,\n",
+    "                                            perturbation_model=\"removal\",\n",
+    "                                            partition_fn=\"sentences\",\n",
+    "                                            progress_bar=None\n",
+    "                                            )\n",
     "\n",
     "# Perform the explanation\n",
     "attribution, parts = explainer.attribution(\n",
@@ -117,7 +112,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/python/interpret_text/generative/model_lib/openai_tooling.py
+++ b/python/interpret_text/generative/model_lib/openai_tooling.py
@@ -10,17 +10,23 @@ DEFAULT_SYSTEM_PROMPT = "You are an AI assistant that helps people find informat
 
 
 class ChatOpenAI:
-    def __init__(self, engine="GPT35", system_prompt=DEFAULT_SYSTEM_PROMPT):
+    def __init__(self, engine="GPT35", encoding="cl100k_base", api_settings=None, system_prompt=DEFAULT_SYSTEM_PROMPT):
+        if api_settings is not None:
+            openai.api_type = api_settings.get("api_type")
+            openai.api_base = api_settings.get("api_base")
+            openai.api_version = api_settings.get("api_version")
+            openai.api_key = api_settings.get("api_key")
         self.system_prompt = system_prompt
         self.engine = engine
-        pass
+        self.encoding = encoding
+        self.tokenizer = tiktoken.get_encoding(encoding)
 
-    def _sample_api_single(self, prompt, temperature=0, max_tokens=8000,
+    def _sample_api_single(self, text, temperature=0, max_tokens=8000,
                            top_p=0.99):
         response = openai.ChatCompletion.create(
             engine=self.engine,
             messages=[{"role": "system", "content": self.system_prompt},
-                      {"role": "user", "content": prompt}],
+                      {"role": "user", "content": text}],
             temperature=temperature,
             max_tokens=max_tokens,
             top_p=top_p,
@@ -28,6 +34,23 @@ class ChatOpenAI:
             presence_penalty=0,
             stop=None)
         return response["choices"][0]["message"]["content"]
+    
+    def sample(self, texts, temperature=0, max_new_tokens=8000,
+                           top_p=0.99):
+        completions = []
+        for p in texts:
+            response = openai.ChatCompletion.create(
+                engine=self.engine,
+                messages=[{"role": "system", "content": self.system_prompt},
+                            {"role": "user", "content": p}],
+                temperature=temperature,
+                max_tokens=max_new_tokens,
+                top_p=top_p,
+                frequency_penalty=0,
+                presence_penalty=0,
+            stop=None)
+            completions.append(response["choices"][0]["message"]["content"])
+        return completions
 
 
 class CompletionsOpenAI:


### PR DESCRIPTION
Previous ChatOpenAI class was not fully defined in OpenAI tooling for generative models. It now has the functionality required to work with gpt-3.5 and gpt-4. 

I added example notebooks for how to use the generative explainers with gpt-3 models which uses CompletionOpenAI class instead of ChatOpenAi. 

Additionally, I created a notebook for gpt-4 as well which an explainer is used that does not require log likelihoods.

I also added a example notebook for huggingface models. 